### PR TITLE
Restaure fonctions météo et courses

### DIFF
--- a/script.js
+++ b/script.js
@@ -150,3 +150,108 @@ async function lineAlert(stop) {
     return msg ? `⚠️ ${msg}` : "";
   } catch { return ""; }
 }
+
+// -------- Actus, météo, courses --------
+async function news() {
+  const elNews = document.getElementById("news-content");
+  try {
+    const r = await fetch(
+      "https://api.rss2json.com/v1/api.json?rss_url=https://www.francetvinfo.fr/titres.rss"
+    );
+    elNews.textContent = (await r.json()).items
+      .slice(0, 3)
+      .map((i) => i.title)
+      .join(" • ");
+  } catch {
+    elNews.textContent = "Actus indisponibles";
+  }
+}
+
+async function afficherProchaineCourseVincennes() {
+  const el = document.getElementById("nextRace");
+  try {
+    const data = await fetch("static/races.json").then((r) => r.json());
+    const now = new Date();
+    const prochaines = data
+      .map((r) => ({
+        ...r,
+        dateTime: r.heure
+          ? new Date(`${r.date}T${r.heure.length === 5 ? r.heure + ':00' : r.heure}`)
+          : new Date(r.date),
+      }))
+      .filter((r) => r.dateTime >= now)
+      .sort((a, b) => a.dateTime - b.dateTime);
+
+    const prochaine = prochaines[0];
+    if (!prochaine) {
+      el.innerHTML = "Aucune réunion Vincennes à venir.";
+      return;
+    }
+
+    const options = {
+      weekday: "short",
+      day: "2-digit",
+      month: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    };
+    const dateStr = prochaine.dateTime.toLocaleString("fr-FR", options);
+    el.innerHTML = `🏇 Prochaine réunion : <b>${prochaine.lieu}</b> (${prochaine.type})<br>📅 ${dateStr}`;
+  } catch (e) {
+    console.error(e);
+    el.innerHTML = "Erreur lors de la détection de la prochaine réunion Equidia.";
+  }
+}
+
+async function afficherToutesCoursesVincennes() {
+  const el = document.getElementById("courses-content");
+  try {
+    const data = await fetch("static/races.json").then((r) => r.json());
+    const now = new Date();
+    const prochaines = data
+      .map((r) => ({
+        ...r,
+        dateTime: r.heure
+          ? new Date(`${r.date}T${r.heure.length === 5 ? r.heure + ':00' : r.heure}`)
+          : new Date(r.date),
+      }))
+      .filter((r) => r.dateTime >= now)
+      .sort((a, b) => a.dateTime - b.dateTime);
+
+    if (!prochaines.length) {
+      el.innerHTML = "<i>Aucune course Vincennes à venir.</i>";
+      return;
+    }
+
+    el.innerHTML = prochaines
+      .map(
+        (c) =>
+          `<div class="course">
+        <b>${c.date}${c.heure ? ' ' + c.heure : ''}</b> – ${c.lieu} (${c.type})
+      </div>`
+      )
+      .join("");
+  } catch (err) {
+    console.error("Erreur Equidia:", err);
+    el.innerHTML = "<b>Erreur de chargement des courses.</b>";
+  }
+}
+
+async function meteo() {
+  const el = document.getElementById("meteo");
+  try {
+    const r = await fetch(
+      "https://api.open-meteo.com/v1/forecast?latitude=48.8402&longitude=2.4274&current_weather=true"
+    );
+    const c = (await r.json()).current_weather;
+    el.innerHTML = `<h2>🌤 Météo locale</h2>${c.temperature} °C | Vent ${c.windspeed} km/h`;
+  } catch {
+    el.textContent = "Erreur météo";
+  }
+}
+
+function startWeatherLoop() {
+  meteo();
+  setInterval(meteo, 30 * 60 * 1000);
+}
+


### PR DESCRIPTION
## Résumé
- réimplémente `news`, `meteo`, `startWeatherLoop`, `afficherProchaineCourseVincennes` et `afficherToutesCoursesVincennes`
- la page charge désormais sans références manquantes

## Tests
- `npm test` *(échoue : script "test" manquant)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_687386f716608333afbd9d3eb2f8f2a2